### PR TITLE
Improve TV autoplay tracking and sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,6 +530,79 @@
     body.theater #playerSection {
       padding-top: 0.4rem;
     }
+
+    /* DEVICE ADAPTIVE STYLES */
+    body.mobile .page {
+      max-width: none;
+      padding: 0.75rem 0.65rem 1.6rem;
+    }
+
+    body.mobile header {
+      gap: 0.4rem;
+    }
+
+    body.mobile .controls {
+      width: 100%;
+      justify-content: space-between;
+      gap: 0.4rem;
+    }
+
+    body.mobile .search-input,
+    body.mobile .select-input {
+      flex: 1 1 0;
+      min-width: 0;
+      font-size: 0.95rem;
+      padding: 0.55rem 0.7rem;
+    }
+
+    body.mobile .nav-btn,
+    body.mobile .btn {
+      padding: 0.55rem 0.85rem;
+      font-size: 0.95rem;
+    }
+
+    body.mobile .item-card {
+      width: clamp(150px, 44vw, 220px);
+    }
+
+    body.mobile .card-row {
+      justify-content: center;
+    }
+
+    body.tv .page {
+      max-width: 1400px;
+      padding: 1.1rem 1rem 2rem;
+    }
+
+    body.tv .nav-btn,
+    body.tv .btn {
+      padding: 0.6rem 1rem;
+      font-size: 1rem;
+      letter-spacing: 0.02em;
+    }
+
+    body.tv .title-block h1 {
+      font-size: 2rem;
+    }
+
+    body.tv .controls {
+      gap: 0.8rem;
+    }
+
+    body.tv .search-input,
+    body.tv .select-input {
+      font-size: 1rem;
+      padding: 0.6rem 0.85rem;
+    }
+
+    body.tv .card-row {
+      justify-content: center;
+      gap: 1rem;
+    }
+
+    body.tv .item-card {
+      width: 180px;
+    }
   </style>
 </head>
 <body>
@@ -540,6 +613,7 @@
         <p>Home, library & player for our Vidking setup.</p>
         <div class="nav">
           <button class="nav-btn active" data-route="home">Home</button>
+          <button class="nav-btn" data-route="search">Search</button>
           <button class="nav-btn" data-route="library">Library</button>
         </div>
       </div>
@@ -558,6 +632,28 @@
         </select>
       </div>
     </header>
+
+    <!-- SEARCH SECTION -->
+    <section id="searchSection" class="section">
+      <section class="tmdb-panel">
+        <h2 class="tmdb-header">Search Results</h2>
+        <div class="tmdb-row">
+          <input
+            id="tmdbSearchInput"
+            class="tmdb-input"
+            type="search"
+            placeholder="Search TMDb (movie / show)…"
+          />
+          <button id="tmdbSearchButton" class="tmdb-button" type="button">
+            Search
+          </button>
+        </div>
+        <div id="tmdbStatus" class="tmdb-status">
+          Type a title above and click Search.
+        </div>
+        <div id="tmdbResults" class="tmdb-results"></div>
+      </section>
+    </section>
 
     <!-- HOME SECTION -->
     <section id="homeSection" class="section active">
@@ -584,26 +680,6 @@
         <span id="popularTvLabel"></span>
       </div>
       <div id="popularTvRow" class="card-row"></div>
-
-      <!-- TMDb search -->
-      <section class="tmdb-panel">
-        <h2 class="tmdb-header">TMDb Search → Add to Library</h2>
-        <div class="tmdb-row">
-          <input
-            id="tmdbSearchInput"
-            class="tmdb-input"
-            type="search"
-            placeholder="Search TMDb (movie / show)…"
-          />
-          <button id="tmdbSearchButton" class="tmdb-button" type="button">
-            Search
-          </button>
-        </div>
-        <div id="tmdbStatus" class="tmdb-status">
-          Type a title above and click Search.
-        </div>
-        <div id="tmdbResults" class="tmdb-results"></div>
-      </section>
     </section>
 
     <!-- LIBRARY SECTION -->
@@ -678,6 +754,8 @@
     let currentEpisode = 1;
     let episodesCache = {};
     let currentRoute = "home";
+    let playerSrcWatcher = null;
+    let lastPlayerSrc = "";
 
     /******************************************************************
      * STORAGE HELPERS
@@ -709,6 +787,7 @@
      ******************************************************************/
     const routeButtons = document.querySelectorAll(".nav-btn");
     const homeSection = document.getElementById("homeSection");
+    const searchSection = document.getElementById("searchSection");
     const librarySection = document.getElementById("librarySection");
     const playerSection = document.getElementById("playerSection");
 
@@ -748,10 +827,11 @@
      * ROUTING
      ******************************************************************/
     function setRoute(route) {
-      const leavingPlayer = (currentRoute === "player" && route !== "player");
+      const leavingPlayer = currentRoute === "player" && route !== "player";
 
       if (leavingPlayer) {
         // clear iframe so Vidking stops audio
+        stopPlayerWatcher();
         playerContainer.innerHTML = "";
         document.body.classList.remove("theater");
         theaterBtn.textContent = "Theater mode";
@@ -760,6 +840,7 @@
       currentRoute = route;
 
       homeSection.classList.remove("active");
+      searchSection.classList.remove("active");
       librarySection.classList.remove("active");
       playerSection.classList.remove("active");
 
@@ -768,6 +849,7 @@
       );
 
       if (route === "home") homeSection.classList.add("active");
+      if (route === "search") searchSection.classList.add("active");
       if (route === "library") librarySection.classList.add("active");
       if (route === "player") playerSection.classList.add("active");
     }
@@ -777,6 +859,8 @@
         setRoute(btn.dataset.route);
         if (btn.dataset.route === "library") {
           renderLibrary();
+        } else if (btn.dataset.route === "search") {
+          tmdbSearchInput?.focus();
         }
       });
     });
@@ -1141,6 +1225,7 @@
         currentItem.lastEpisode = currentEpisode;
         markWatched(currentItem);
         renderPlayerDetails();
+        startPlayerWatcher();
       });
     }
 
@@ -1148,10 +1233,68 @@
      * PLAYER
      ******************************************************************/
     function buildVidkingUrl(item, season = 1, episode = 1) {
+      const autoplayParams = "autoplay=true";
       if (item.type === "movie") {
-        return `https://www.vidking.net/embed/movie/${item.tmdbId}?autoPlay=true`;
-      } else {
-        return `https://www.vidking.net/embed/tv/${item.tmdbId}/${season}/${episode}?autoPlay=true&nextEpisode=true&episodeSelector=true`;
+        return `https://www.vidking.net/embed/movie/${item.tmdbId}?${autoplayParams}`;
+      }
+
+      const base = `https://www.vidking.net/embed/tv/${item.tmdbId}/${season}/${episode}`;
+      return `${base}?${autoplayParams}&nextEpisode=true&episodeSelector=true&autonext=true`;
+    }
+
+    function stopPlayerWatcher() {
+      if (playerSrcWatcher) {
+        clearInterval(playerSrcWatcher);
+        playerSrcWatcher = null;
+      }
+    }
+
+    function syncEpisodeFromSrc(src) {
+      const match = src.match(/\/tv\/(\d+)\/(\d+)\/(\d+)/);
+      if (!match || !currentItem) return;
+
+      const [, tmdbId, seasonStr, epStr] = match;
+      if (String(tmdbId) !== String(currentItem.tmdbId)) return;
+
+      const parsedSeason = parseInt(seasonStr, 10);
+      const parsedEpisode = parseInt(epStr, 10);
+      if (Number.isFinite(parsedSeason)) currentSeason = parsedSeason;
+      if (Number.isFinite(parsedEpisode)) currentEpisode = parsedEpisode;
+
+      currentItem.lastSeason = currentSeason;
+      currentItem.lastEpisode = currentEpisode;
+      markWatched(currentItem);
+      renderEpisodeList(currentItem, currentSeason, currentEpisode);
+      renderPlayerDetails();
+    }
+
+    function startPlayerWatcher() {
+      stopPlayerWatcher();
+      const iframe = playerContainer.querySelector("iframe");
+      if (!iframe) return;
+      lastPlayerSrc = iframe.getAttribute("src") || "";
+      if (lastPlayerSrc) syncEpisodeFromSrc(lastPlayerSrc);
+
+      playerSrcWatcher = setInterval(() => {
+        const src = iframe.getAttribute("src") || "";
+        if (src && src !== lastPlayerSrc) {
+          lastPlayerSrc = src;
+          syncEpisodeFromSrc(src);
+        }
+      }, 1500);
+    }
+
+    function detectDevice() {
+      const ua = navigator.userAgent || "";
+      const isAndroidTv = /Android TV|BRAVIA|SMART-TV|HbbTV|NETTV/i.test(ua);
+      const isMobile = !isAndroidTv && /Mobi|Android|iPhone|iPad|iPod/i.test(ua);
+
+      if (isAndroidTv) {
+        document.body.classList.add("tv");
+      }
+
+      if (isMobile) {
+        document.body.classList.add("mobile");
       }
     }
 
@@ -1303,6 +1446,7 @@
           item.lastEpisode = currentEpisode;
           markWatched(item);
           renderPlayerDetails();
+          startPlayerWatcher();
         });
 
         episodeList.appendChild(row);
@@ -1332,6 +1476,7 @@
 
       markWatched(item);
       renderPlayerDetails();
+      startPlayerWatcher();
       setRoute("player");
       window.scrollTo({ top: 0, behavior: "smooth" });
 
@@ -1424,6 +1569,8 @@
      ******************************************************************/
     async function searchTmdb(query) {
       const q = query.trim();
+      setRoute("search");
+
       if (!q) {
         tmdbStatusEl.textContent = "Type a title to search TMDb.";
         tmdbResultsEl.innerHTML = "";
@@ -1436,6 +1583,7 @@
         return;
       }
 
+      window.scrollTo({ top: 0, behavior: "smooth" });
       tmdbStatusEl.textContent = "Searching TMDb…";
       tmdbResultsEl.innerHTML = "";
 
@@ -1519,7 +1667,7 @@
           : "Add show to library";
         addBtn.addEventListener("click", () => {
           const item = addToLibraryFromTmdbResult(r, isMovie);
-          openPlayer(item, { fromRoute: "home" });
+          openPlayer(item, { fromRoute: "search" });
         });
 
         actions.appendChild(addBtn);
@@ -1534,14 +1682,14 @@
           const item = addToLibraryFromTmdbResult(r, isMovie, {
             makeWatchlist: true
           });
-          if (!item.isWatchlist) {
-            item.isWatchlist = true;
-            saveLibrary();
-          }
-          renderHome();
-          renderLibrary();
-          openPlayer(item, { fromRoute: "home" });
-        });
+            if (!item.isWatchlist) {
+              item.isWatchlist = true;
+              saveLibrary();
+            }
+            renderHome();
+            renderLibrary();
+            openPlayer(item, { fromRoute: "search" });
+          });
 
         actions.appendChild(watchlistBtn);
         body.appendChild(actions);
@@ -1603,6 +1751,7 @@
      * INIT
      ******************************************************************/
     function init() {
+      detectDevice();
       loadLibraryFromStorage();
       renderLibrary();
       renderHome();


### PR DESCRIPTION
## Summary
- switch Vidking embed URLs to use lowercase autoplay parameters with autonext hints for TV playback
- add iframe source watcher to detect episode advances and keep library progress in sync when autoplay moves forward
- start/stop the player watcher around route changes and episode selection to better support Android TV autoplay

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e0d7b5c4c8321b52636197e400526)