### PR TITLE
Fix autoplay permission for auto-advanced episodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1712,6 +1712,7 @@
           <iframe
             src="${src}"
             frameborder="0"
+            allow="autoplay; fullscreen"
             allowfullscreen
           ></iframe>
         `;


### PR DESCRIPTION
## Summary
- add autoplay permission to auto-advanced episode iframe to keep playback seamless

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc006afc08321a37806a6aca164e3)