### PR TITLE
Fix theater mode player sizing and centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 
     body.theater {
       background: #000;
+      overflow-x: hidden;
     }
 
     .page {
@@ -306,8 +307,32 @@
       height: 100%;
     }
 
+    /* Player wrapper uses full viewport size in theater mode */
     body.theater .player-wrapper {
       max-width: none;
+      width: 100vw;
+      height: 100vh;
+      margin: 0;
+    }
+
+    /* Inner aspect box: fill height, center iframe, black background */
+    body.theater .player-aspect {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      padding-bottom: 0; /* remove 16:9 padding; we control via height now */
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #000;
+    }
+
+    /* Iframe scales to height, keeps aspect ratio, no overflow */
+    body.theater .player-aspect iframe {
+      position: relative;
+      width: auto;
+      height: 100%;
+      max-width: 100%;
     }
 
     #playerBottomRow {
@@ -473,7 +498,7 @@
     }
 
     body.theater #playerSection {
-      padding-top: 0.4rem;
+      padding: 0;
     }
 
     /* DEVICE ADAPTIVE STYLES */


### PR DESCRIPTION
## Summary
- add theater-mode layout rules to keep the player full height and centered
- ensure iframe scales to viewport height with black sidebars on wide screens
- prevent horizontal scrolling when theater mode is active

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934795fb1b48321964593d321ec869e)